### PR TITLE
Limited precision floating point calculations

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -41,7 +41,7 @@ function join(arg){
 }
 function equal(){
 if(document.getElementById('display').innerHTML!='')    
-document.getElementById('display').innerHTML=eval(document.getElementById('display').innerHTML);
+document.getElementById('display').innerHTML=eval(document.getElementById('display').innerHTML).toFixed(2);
 navigator.vibrate(80);
 }
 function clearL(){


### PR DESCRIPTION
Earlier when I multiplied floating point number like 12 * 1.1 I was getting a number with 10 digits after decimal which exceeded the width of the display.
I have rounded off the result to 2 decimal places so that it doesn't happen.
Let me know if I should make any changes.